### PR TITLE
Add game over handling on zero HP

### DIFF
--- a/data/cards.json
+++ b/data/cards.json
@@ -1,0 +1,51 @@
+[
+  {
+    "id": "goblin",
+    "name": "Goblin",
+    "type": "monster",
+    "cost": 1,
+    "atk": 1,
+    "def": 1,
+    "effects": [
+      {"trigger": "on_play", "effect": "buff_self_atk", "value": 1}
+    ]
+  },
+  {
+    "id": "knight",
+    "name": "Knight",
+    "type": "monster",
+    "cost": 3,
+    "atk": 3,
+    "def": 4,
+    "effects": []
+  },
+  {
+    "id": "cleric",
+    "name": "Cleric",
+    "type": "monster",
+    "cost": 2,
+    "atk": 1,
+    "def": 3,
+    "effects": [
+      {"trigger": "on_attack", "effect": "heal_self_def", "value": 1}
+    ]
+  },
+  {
+    "id": "fireball",
+    "name": "Fireball",
+    "type": "spell",
+    "cost": 2,
+    "effects": [
+      {"trigger": "on_play", "effect": "deal_damage_player", "value": 3}
+    ]
+  },
+  {
+    "id": "inspiration",
+    "name": "Inspiration",
+    "type": "spell",
+    "cost": 1,
+    "effects": [
+      {"trigger": "on_play", "effect": "draw_cards", "value": 2}
+    ]
+  }
+]

--- a/data/deck_ai.json
+++ b/data/deck_ai.json
@@ -1,0 +1,3 @@
+[
+  "goblin","goblin","knight","knight","fireball","fireball","inspiration","inspiration","cleric","cleric"
+]

--- a/data/deck_player.json
+++ b/data/deck_player.json
@@ -1,0 +1,3 @@
+[
+  "goblin","goblin","knight","knight","fireball","fireball","inspiration","inspiration","cleric","cleric"
+]

--- a/scenes/Main.tscn
+++ b/scenes/Main.tscn
@@ -1,0 +1,6 @@
+[gd_scene load_steps=2 format=3]
+
+[ext_resource path="res://scripts/Game.gd" type="Script" id=1]
+
+[node name="Main" type="Node"]
+script = ExtResource(1)

--- a/scripts/AIPlayer.gd
+++ b/scripts/AIPlayer.gd
@@ -1,0 +1,22 @@
+extends "res://scripts/Player.gd"
+class_name AIPlayer
+
+func perform_main_phase(game):
+    for card in hand.cards.duplicate():
+        if card.cost <= energy:
+            var slot = board.get_free_slot(index, card.type)
+            if slot:
+                play_card(card, slot, game.players[0])
+
+func perform_battle_phase(game):
+    for i in range(3):
+        var slot = board.get_monster_slot(index, i)
+        var card = slot.card
+        if card:
+            var opp_slot = board.get_monster_slot(1 - index, i)
+            if opp_slot.card:
+                card.attack(opp_slot.card, game.players[0])
+                if opp_slot.card.def <= 0:
+                    opp_slot.card = null
+            else:
+                game.players[0].take_damage(card.atk)

--- a/scripts/Board.gd
+++ b/scripts/Board.gd
@@ -1,0 +1,28 @@
+extends Node
+class_name Board
+
+var monster_slots: Array = []
+var spell_slots: Array = []
+
+func _init():
+    # Two players: index 0 player, 1 AI
+    monster_slots = [[], []]
+    spell_slots = [[], []]
+    for i in range(3):
+        monster_slots[0].append(Slot.new("monster"))
+        monster_slots[1].append(Slot.new("monster"))
+        spell_slots[0].append(Slot.new("spell"))
+        spell_slots[1].append(Slot.new("spell"))
+
+func get_monster_slot(player_index: int, column: int) -> Slot:
+    return monster_slots[player_index][column]
+
+func get_spell_slot(player_index: int, column: int) -> Slot:
+    return spell_slots[player_index][column]
+
+func get_free_slot(player_index: int, type: String) -> Slot:
+    var arr = type == "monster" ? monster_slots[player_index] : spell_slots[player_index]
+    for s in arr:
+        if s.is_empty():
+            return s
+    return null

--- a/scripts/CardModel.gd
+++ b/scripts/CardModel.gd
@@ -1,0 +1,25 @@
+extends Resource
+class_name CardModel
+
+var id: String = ""
+var name: String = ""
+var type: String = "monster"
+var cost: int = 0
+var atk: int = 0
+var def: int = 0
+var effects: Array = []
+
+func from_dict(data: Dictionary) -> CardModel:
+    id = data.get("id", "")
+    name = data.get("name", "")
+    type = data.get("type", "monster")
+    cost = data.get("cost", 0)
+    atk = data.get("atk", 0)
+    def = data.get("def", 0)
+    effects = data.get("effects", [])
+    return self
+
+func trigger(event_name: String, ctx: Dictionary):
+    for eff in effects:
+        if eff.get("trigger") == event_name:
+            EffectSystem.apply_effect(self, eff, ctx)

--- a/scripts/CardNode.gd
+++ b/scripts/CardNode.gd
@@ -1,0 +1,20 @@
+extends Button
+class_name CardNode
+
+var card_model: CardModel
+signal card_clicked(card)
+
+func set_card(card):
+    card_model = card
+    _update_display()
+
+func _update_display():
+    if card_model == null:
+        text = ""
+        return
+    text = "%s\nCost:%d" % [card_model.name, card_model.cost]
+    if card_model is MonsterCardModel:
+        text += "\nATK:%d DEF:%d" % [card_model.atk, card_model.def]
+
+func _pressed():
+    emit_signal("card_clicked", card_model)

--- a/scripts/EffectSystem.gd
+++ b/scripts/EffectSystem.gd
@@ -1,0 +1,19 @@
+extends Node
+class_name EffectSystem
+
+static func apply_effect(card, eff: Dictionary, ctx: Dictionary):
+    var effect = eff.get("effect")
+    var value = eff.get("value", 0)
+    match effect:
+        "buff_self_atk":
+            card.atk += value
+        "heal_self_def":
+            card.def += value
+        "deal_damage_player":
+            var target = ctx.get("opponent")
+            if target:
+                target.take_damage(value)
+        "draw_cards":
+            var player = ctx.get("player")
+            if player:
+                player.draw(value)

--- a/scripts/Game.gd
+++ b/scripts/Game.gd
@@ -1,0 +1,197 @@
+extends Node
+class_name Game
+
+var card_definitions: Dictionary = {}
+var players: Array = []
+var board: Board
+var turn_manager: TurnManager
+var game_over: bool = false
+
+# UI nodes
+var phase_label
+var energy_label
+var hp_label_player
+var hp_label_ai
+var winner_label
+var hand_container
+var board_monsters_player_container
+var board_spells_player_container
+var board_monsters_ai_container
+var board_spells_ai_container
+
+func _ready():
+    load_cards()
+    setup_game()
+    build_ui()
+    turn_manager.start_turn()
+    refresh_all()
+
+func load_cards():
+    var file = FileAccess.open("res://data/cards.json", FileAccess.READ)
+    var data = JSON.parse_string(file.get_as_text())
+    for d in data:
+        card_definitions[d.id] = d
+
+func create_card(id: String) -> CardModel:
+    var data = card_definitions[id]
+    var card
+    if data.type == "monster":
+        card = MonsterCardModel.new()
+    else:
+        card = SpellCardModel.new()
+    card.from_dict(data.duplicate())
+    return card
+
+func load_deck(path: String) -> Array:
+    var file = FileAccess.open(path, FileAccess.READ)
+    var data = JSON.parse_string(file.get_as_text())
+    return data
+
+func setup_game():
+    board = Board.new()
+    var deck_player = load_deck("res://data/deck_player.json")
+    var deck_ai = load_deck("res://data/deck_ai.json")
+    var player = Player.new(self, deck_player, board, 0)
+    var ai = AIPlayer.new(self, deck_ai, board, 1)
+    players = [player, ai]
+    turn_manager = TurnManager.new(self)
+
+func build_ui():
+    var ui = Control.new()
+    add_child(ui)
+    var vbox = VBoxContainer.new()
+    ui.add_child(vbox)
+    phase_label = Label.new()
+    vbox.add_child(phase_label)
+    energy_label = Label.new()
+    vbox.add_child(energy_label)
+    var hp_box = HBoxContainer.new()
+    vbox.add_child(hp_box)
+    hp_label_player = Label.new()
+    hp_box.add_child(hp_label_player)
+    hp_label_ai = Label.new()
+    hp_box.add_child(hp_label_ai)
+    winner_label = Label.new()
+    vbox.add_child(winner_label)
+    var board_box = VBoxContainer.new()
+    vbox.add_child(board_box)
+    board_monsters_ai_container = HBoxContainer.new()
+    board_box.add_child(board_monsters_ai_container)
+    board_spells_ai_container = HBoxContainer.new()
+    board_box.add_child(board_spells_ai_container)
+    board_spells_player_container = HBoxContainer.new()
+    board_box.add_child(board_spells_player_container)
+    board_monsters_player_container = HBoxContainer.new()
+    board_box.add_child(board_monsters_player_container)
+    hand_container = HBoxContainer.new()
+    vbox.add_child(hand_container)
+    var buttons = HBoxContainer.new()
+    vbox.add_child(buttons)
+    var next_btn = Button.new()
+    next_btn.text = "Siguiente Fase"
+    buttons.add_child(next_btn)
+    next_btn.pressed.connect(_on_next_phase)
+    var end_btn = Button.new()
+    end_btn.text = "Fin Turno"
+    buttons.add_child(end_btn)
+    end_btn.pressed.connect(_on_end_turn)
+
+func refresh_all():
+    update_ui()
+    refresh_hand()
+    refresh_board()
+
+func update_ui():
+    phase_label.text = "Fase: %s" % turn_manager.get_phase()
+    var current = players[turn_manager.current_player_index]
+    energy_label.text = "Energia: %d/%d" % [current.energy, current.max_energy]
+    hp_label_player.text = "HP Jugador: %d" % players[0].hp
+    hp_label_ai.text = "HP IA: %d" % players[1].hp
+
+func refresh_hand():
+    for c in hand_container.get_children():
+        c.queue_free()
+    for card in players[0].hand.cards:
+        var node = CardNode.new()
+        node.set_card(card)
+        node.card_clicked.connect(_on_hand_card_clicked)
+        hand_container.add_child(node)
+
+func refresh_board():
+    for c in board_monsters_ai_container.get_children(): c.queue_free()
+    for c in board_spells_ai_container.get_children(): c.queue_free()
+    for c in board_spells_player_container.get_children(): c.queue_free()
+    for c in board_monsters_player_container.get_children(): c.queue_free()
+    for i in range(3):
+        board_monsters_ai_container.add_child(_create_slot_display(board.get_monster_slot(1, i)))
+        board_spells_ai_container.add_child(_create_slot_display(board.get_spell_slot(1, i)))
+        board_spells_player_container.add_child(_create_slot_display(board.get_spell_slot(0, i)))
+        board_monsters_player_container.add_child(_create_slot_display(board.get_monster_slot(0, i)))
+
+func check_game_over():
+    if game_over:
+        return
+    for i in range(players.size()):
+        if players[i].hp <= 0:
+            end_game(1 - i)
+            break
+
+func end_game(winner_index: int):
+    game_over = true
+    var text = winner_index == 0 ? "Jugador gana!" : "IA gana!"
+    winner_label.text = "Juego terminado: %s" % text
+    refresh_all()
+
+func _create_slot_display(slot: Slot) -> Control:
+    var btn = Button.new()
+    if slot.card:
+        btn.text = slot.card.name
+    else:
+        btn.text = "-"
+    return btn
+
+func _on_hand_card_clicked(card: CardModel):
+    if game_over:
+        return
+    var player = players[0]
+    var slot = board.get_free_slot(0, card.type)
+    if slot and card.cost <= player.energy:
+        player.play_card(card, slot, players[1])
+        refresh_all()
+
+func _on_next_phase():
+    if game_over:
+        return
+    turn_manager.next_phase()
+    refresh_all()
+
+func _on_end_turn():
+    if game_over:
+        return
+    if turn_manager.get_phase() != "END":
+        return
+    turn_manager.end_turn()
+    refresh_all()
+    if turn_manager.current_player_index == 1:
+        ai_turn()
+
+func ai_turn():
+    if game_over:
+        return
+    var ai = players[1]
+    turn_manager.current_phase_index = 1
+    update_ui()
+    ai.perform_main_phase(self)
+    refresh_board()
+    if game_over:
+        return
+    turn_manager.current_phase_index = 2
+    update_ui()
+    ai.perform_battle_phase(self)
+    refresh_board()
+    if game_over:
+        return
+    turn_manager.current_phase_index = 3
+    update_ui()
+    turn_manager.end_turn()
+    refresh_all()

--- a/scripts/Hand.gd
+++ b/scripts/Hand.gd
@@ -1,0 +1,13 @@
+extends Node
+class_name Hand
+
+var cards: Array = []
+
+func add_card(card: CardModel) -> bool:
+    if cards.size() >= 7:
+        return false
+    cards.append(card)
+    return true
+
+func remove_card(card: CardModel):
+    cards.erase(card)

--- a/scripts/MonsterCardModel.gd
+++ b/scripts/MonsterCardModel.gd
@@ -1,0 +1,17 @@
+extends "res://scripts/CardModel.gd"
+class_name MonsterCardModel
+
+func attack(target, opponent):
+    trigger("on_attack", {"self": self, "target": target, "opponent": opponent})
+    if target:
+        target.receive_damage(atk, opponent)
+    else:
+        opponent.take_damage(atk)
+
+func receive_damage(amount: int, opponent):
+    def -= amount
+    trigger("on_receive_attack", {"self": self, "amount": amount, "opponent": opponent})
+    if def <= 0:
+        trigger("on_destroy", {"self": self, "opponent": opponent})
+        return true
+    return false

--- a/scripts/Player.gd
+++ b/scripts/Player.gd
@@ -1,0 +1,42 @@
+extends Node
+class_name Player
+
+var game
+var index: int = 0
+var deck: Array = []
+var hand: Hand = Hand.new()
+var board: Board
+var hp: int = 20
+var max_energy: int = 0
+var energy: int = 0
+
+func _init(_game, _deck: Array, _board: Board, _index: int):
+    game = _game
+    deck = _deck
+    board = _board
+    index = _index
+
+func draw(n: int = 1):
+    for i in range(n):
+        if deck.is_empty():
+            break
+        var id = deck.pop_front()
+        var card = game.create_card(id)
+        hand.add_card(card)
+
+func play_card(card: CardModel, slot: Slot, opponent) -> bool:
+    if card.cost > energy:
+        return false
+    if not slot.is_empty():
+        return false
+    energy -= card.cost
+    hand.remove_card(card)
+    slot.card = card
+    card.trigger("on_play", {"player": self, "opponent": opponent, "slot": slot, "self": card})
+    if card.type == "spell":
+        slot.card = null
+    return true
+
+func take_damage(amount: int):
+    hp -= amount
+    game.check_game_over()

--- a/scripts/Slot.gd
+++ b/scripts/Slot.gd
@@ -1,0 +1,11 @@
+extends RefCounted
+class_name Slot
+
+var type: String
+var card: CardModel = null
+
+func _init(_type: String):
+    type = _type
+
+func is_empty() -> bool:
+    return card == null

--- a/scripts/SpellCardModel.gd
+++ b/scripts/SpellCardModel.gd
@@ -1,0 +1,5 @@
+extends "res://scripts/CardModel.gd"
+class_name SpellCardModel
+
+func resolve(player, opponent, slot):
+    trigger("on_play", {"player": player, "opponent": opponent, "slot": slot, "self": self})

--- a/scripts/TurnManager.gd
+++ b/scripts/TurnManager.gd
@@ -1,0 +1,31 @@
+extends Node
+class_name TurnManager
+
+var phases = ["DRAW", "MAIN", "BATTLE", "END"]
+var current_phase_index: int = 0
+var current_player_index: int = 0
+var game
+
+func _init(_game):
+    game = _game
+
+func start_turn():
+    current_phase_index = 0
+    var player = game.players[current_player_index]
+    player.max_energy = min(player.max_energy + 1, 10)
+    player.energy = player.max_energy
+    player.draw(1)
+    game.update_ui()
+
+func next_phase():
+    if current_phase_index < phases.size() - 1:
+        current_phase_index += 1
+    game.update_ui()
+
+func end_turn():
+    current_phase_index = 0
+    current_player_index = (current_player_index + 1) % game.players.size()
+    start_turn()
+
+func get_phase() -> String:
+    return phases[current_phase_index]


### PR DESCRIPTION
## Summary
- track game state and show winner message when a player's HP hits zero
- block further phases and actions after the game ends

## Testing
- `godot --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6897efec3e048322b4ad6c5729fa5eb1